### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>au.org.ala</groupId>
         <artifactId>ala-parent-pom</artifactId>
-        <version>1.0</version>
+        <version>6</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>com.googlecode.json-simple</groupId>
             <artifactId>json-simple</artifactId>
-            <version>1.1</version>
+            <version>1.1.1</version>
         </dependency>
 
 
@@ -121,7 +121,7 @@
         <dependency>
             <groupId>net.sf.opencsv</groupId>
             <artifactId>opencsv</artifactId>
-            <version>2.1</version>
+            <version>2.3</version>
         </dependency>
 
         <!--dependency>
@@ -149,7 +149,7 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
+            <version>1.2.17</version>
         </dependency>
         <!--dependency>
             <groupId>com.jhlabs</groupId>
@@ -190,7 +190,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.4</version>
+            <version>1.11</version>
         </dependency>
 
         <!--
@@ -208,7 +208,7 @@
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
-            <version>1.3.1</version>
+            <version>1.6</version>
         </dependency>
         <!--dependency>
             <groupId>oro</groupId>
@@ -218,12 +218,12 @@
         <dependency>
             <groupId>org.apache.xmlbeans</groupId>
             <artifactId>xmlbeans</artifactId>
-            <version>2.4.0</version>
+            <version>2.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlbeans</groupId>
             <artifactId>xmlbeans-xmlpublic</artifactId>
-            <version>2.4.0</version>
+            <version>2.6.0</version>
         </dependency>
         <!--dependency>
             <groupId>com.ibm.icu</groupId>
@@ -282,12 +282,12 @@
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
-            <version>1.4.2</version>
+            <version>1.4.10-java7</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-mapper-asl</artifactId>
-            <version>1.9.3</version>
+            <version>1.9.13</version>
         </dependency>
         <!--dependency>
             <groupId>au.org.ala</groupId>
@@ -643,7 +643,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.7</version>
+            <version>1.7.25</version>
         </dependency>
 
         <dependency>
@@ -729,10 +729,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.0.2</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>${targetJdk}</source>
+                    <target>${targetJdk}</target>
                     <compilerArgument>-g:lines,vars,source</compilerArgument>
                 </configuration>
             </plugin>
@@ -751,7 +750,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.4.2</version>
                 <configuration>
                     <includes>
                         <include>**/*Tests.java</include>
@@ -769,7 +767,7 @@
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
+                    <source>${targetJdk}</source>
                     <doclet>
                         gr.spinellis.umlgraph.doclet.UmlGraphDoc
                     </doclet>
@@ -792,7 +790,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.0</version>
             </plugin>
 
         </plugins>
@@ -809,17 +806,23 @@
         <zk.version>7.0.1</zk.version>
         <zkspring.version>3.1.1</zkspring.version>
         <spring.version>3.0.7.RELEASE</spring.version>
-        <springsecurity.version>3.1.2.RELEASE</springsecurity.version>
-        <commons-fileupload.version>1.2.1</commons-fileupload.version>
-        <commons-io.version>1.4</commons-io.version>
+        <commons-fileupload.version>1.3.3</commons-fileupload.version>
+        <commons-io.version>2.6</commons-io.version>
         <servlet-api.version>2.4</servlet-api.version>
         <jstl-api.version>1.1.2</jstl-api.version>
-        <junit.version>4.7</junit.version>
+        <junit.version>4.12</junit.version>
         <concurrent.version>1.3.4</concurrent.version>
-        <commons-lang.version>2.5</commons-lang.version>
-        <javassist.version>3.14.0-GA</javassist.version>
+        <commons-lang.version>2.6</commons-lang.version>
+        <javassist.version>3.22.0-GA</javassist.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- Java target, including verification that only APIs from that target have been used -->
+        <!-- Default to 1.8, but can be overridden in child projects as necessary -->
+        <targetJdk>1.7</targetJdk>
+        <animal-sniffer-signature.artifact>java17</animal-sniffer-signature.artifact>
+        <animal-sniffer-signature.version>1.0</animal-sniffer-signature.version>
+
     </properties>
 
 </project>

--- a/src/main/java/au/org/ala/spatial/composer/tool/GDMComposer.java
+++ b/src/main/java/au/org/ala/spatial/composer/tool/GDMComposer.java
@@ -387,9 +387,9 @@ public class GDMComposer extends ToolComposer {
             StringBuilder sbProcessUrl = new StringBuilder();
             sbProcessUrl.append(CommonData.getSatServer()).append("/ws/gdm/step2?");
             sbProcessUrl.append("&pid=").append(pid);
-            sbProcessUrl.append("&cutpoint=").append(cutpoint.getSelectedItem().getValue());
-            sbProcessUrl.append("&useDistance=").append(rgdistance.getSelectedItem().getValue());
-            sbProcessUrl.append("&weighting=").append(weighting.getSelectedItem().getValue());
+            sbProcessUrl.append("&cutpoint=").append((char[])cutpoint.getSelectedItem().getValue());
+            sbProcessUrl.append("&useDistance=").append((char[])rgdistance.getSelectedItem().getValue());
+            sbProcessUrl.append("&weighting=").append((char[])weighting.getSelectedItem().getValue());
             sbProcessUrl.append("&useSubSample=").append(useSubSample.isChecked() ? "1" : "0");
             sbProcessUrl.append("&sitePairsSize=").append(sitePairsSize.getValue());
             sbProcessUrl.append("&name=").append(query.getName());


### PR DESCRIPTION
Updates dependencies to more recent versions. Does not update where APIs changed, such as Jackson-1 to Jackson-2 or the OpenCSV-4 code.

Note, there are no tests in this project, so these updates may break functionality.

Also fixes one compile failure when compiling on recent JDKs, due to a new StringBuilder method.